### PR TITLE
Fix subshell variable issue

### DIFF
--- a/ExternalNetwork.sh
+++ b/ExternalNetwork.sh
@@ -18,16 +18,20 @@ if [ -z $PROVIDER_CIDR ]; then
   exit -1
 fi
 
-PROVIDER_ID=`openstack network create --share \
+export PROVIDER_ID=`openstack network create --share \
 		--provider-physical-network provider \
 		--provider-network-type flat provider \
 		--external \
         	-f value -c id`
 
-SUBNET_ID=`openstack subnet create              \
+echo "Network ID is '${PROVIDER_ID}'"
+
+export SUBNET_ID=`openstack subnet create              \
         --network ${PROVIDER_ID}                   \
         --subnet-range $PROVIDER_CIDR         \
         $PROVIDER_CIDR -f value -c id`
+
+echo "Subnet ID is '${SUBNET_ID}'"
 
 # assign this gateway to all routers
 for ROUTER_ID in `openstack router list -f value -c ID`


### PR DESCRIPTION
`PROVIDER_ID` wasn't set in the second invocation of `openstack` until I modified the scripts as follows. I also added some output to make it easier to pick up such issues.
